### PR TITLE
Add "Import from active sprint" button and allow highlighting from boards with no swimlanes

### DIFF
--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -27,12 +27,12 @@ export default function App() {
     }
   }, [persons]);
 
-  const onAddPerson = () => {
+  const onAddPerson = (name: '') => {
     const newPerson = {
       hasCompleted: false,
       id: v4(),
       index: persons.length,
-      name: '',
+      name,
     };
 
     setPersons((previousPersons) => [...previousPersons, newPerson]);

--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -7,7 +7,7 @@ import Icebreaker from '../icebreaker';
 import PersonsList from '../persons-list';
 import { loadPersons, deletePerson, savePerson } from '../../util/idb';
 import { getPersonIndex } from '../../util';
-import { closeAllSwimLanes, highlightSwimLane } from '../../util/klondike';
+import { closePeopleFilters, highlightPerson } from '../../util/klondike';
 import type { Person } from '../../util/types';
 import './index.scss';
 
@@ -21,9 +21,9 @@ export default function App() {
     setActivePersonId(nextPerson?.id);
 
     if (nextPerson) {
-      highlightSwimLane(nextPerson.name);
+      highlightPerson(nextPerson.name);
     } else {
-      closeAllSwimLanes();
+      closePeopleFilters();
     }
   }, [persons]);
 
@@ -130,7 +130,7 @@ export default function App() {
     const prevActivePersonId = activePersonId;
     const nextPerson = persons[personIndex];
     setActivePersonId(personId);
-    highlightSwimLane(nextPerson.name);
+    highlightPerson(nextPerson.name);
 
     setPersons((previousPersons) => {
       return previousPersons.map((person) => {

--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -27,7 +27,7 @@ export default function App() {
     }
   }, [persons]);
 
-  const onAddPerson = (name: '') => {
+  const onAddPerson = (name = '') => {
     const newPerson = {
       hasCompleted: false,
       id: v4(),
@@ -120,7 +120,7 @@ export default function App() {
       });
     });
 
-    setActivePersonId(undefined);
+    closePeopleFilters();
   };
 
   const onSelectNextPerson = (personId: string) => {

--- a/src/components/persons-list/index.scss
+++ b/src/components/persons-list/index.scss
@@ -78,6 +78,10 @@
       }
     }
 
+    &.import-from-active-sprints {
+      background-color: #7bca6e;
+    }
+
     button {
       background: none;
       border: none;

--- a/src/components/persons-list/index.tsx
+++ b/src/components/persons-list/index.tsx
@@ -303,19 +303,21 @@ export default function PersonsList(props: PersonsListProps) {
 
   const getEmptyMessage = () => {
     const onImportClick = () => {
-      const assignees = document.querySelectorAll("label[data-test-id='common.issue-filter-bar.assignee-filter-avatar'] span[role='img']");
-      assignees.forEach(assignee => {
+      const assignees = document.querySelectorAll(
+        "label[data-test-id='common.issue-filter-bar.assignee-filter-avatar'] span[role='img']",
+      );
+      assignees.forEach((assignee) => {
         props.onAddPerson(assignee.getAttribute('aria-label')!);
       });
 
-      const showMore = document.querySelector<HTMLElement>("#ASSIGNEE-show-more");
-      if(!showMore) return;
+      const showMore = document.querySelector<HTMLElement>('#ASSIGNEE-show-more');
+      if (!showMore) return;
 
       showMore.click();
       const otherAssignees = document.querySelectorAll("span[data-role='droplistItem']");
 
       // Ignore last element as it's "Unassigned"
-      for(let index = 0; index < otherAssignees.length - 1; index++){
+      for (let index = 0; index < otherAssignees.length - 1; index++) {
         props.onAddPerson(otherAssignees[index].children[2].textContent!);
       }
       showMore.click();
@@ -325,11 +327,11 @@ export default function PersonsList(props: PersonsListProps) {
     const importFromActiveSprintItem = (
       <li className="import-from-active-sprints">
         <div>
-            <button onClick={onImportClick}>
-                Import from active sprints
-            </button>
+          <button onClick={onImportClick}>Import from active sprints</button>
         </div>
-      </li>);
+      </li>
+    );
+
     return [msgListItem, importFromActiveSprintItem];
   };
 

--- a/src/components/persons-list/index.tsx
+++ b/src/components/persons-list/index.tsx
@@ -27,7 +27,7 @@ import './index.scss';
 interface PersonsListProps {
   activePersonId?: string;
   persons: Person[];
-  onAddPerson: () => Person;
+  onAddPerson: (name?: string) => Person;
   onClear: () => void;
   onDeletePerson: (personId: string) => void;
   onMovePerson: (personId: string, moveIndex: number) => void;
@@ -302,8 +302,35 @@ export default function PersonsList(props: PersonsListProps) {
   };
 
   const getEmptyMessage = () => {
+    const onImportClick = () => {
+      const assignees = document.querySelectorAll("label[data-test-id='common.issue-filter-bar.assignee-filter-avatar'] span[role='img']");
+      assignees.forEach(assignee => {
+        props.onAddPerson(assignee.getAttribute('aria-label')!);
+      });
+
+      const showMore = document.querySelector<HTMLElement>("#ASSIGNEE-show-more");
+      if(!showMore) return;
+
+      showMore.click();
+      const otherAssignees = document.querySelectorAll("span[data-role='droplistItem']");
+
+      // Ignore last element as it's "Unassigned"
+      for(let index = 0; index < otherAssignees.length - 1; index++){
+        props.onAddPerson(otherAssignees[index].children[2].textContent!)
+      }
+      showMore.click();
+    };
+
     const msgListItem = <li>Your standup is empty.</li>;
-    return [msgListItem];
+    const importFromActiveSprintItem = (
+      <li className="import-from-active-sprints">
+        <div>
+            <button onClick={onImportClick}>
+                Import from active sprints
+            </button>
+        </div>
+      </li>);
+    return [msgListItem, importFromActiveSprintItem];
   };
 
   const getTopActionsBar = () => {

--- a/src/components/persons-list/index.tsx
+++ b/src/components/persons-list/index.tsx
@@ -316,7 +316,7 @@ export default function PersonsList(props: PersonsListProps) {
 
       // Ignore last element as it's "Unassigned"
       for(let index = 0; index < otherAssignees.length - 1; index++){
-        props.onAddPerson(otherAssignees[index].children[2].textContent!)
+        props.onAddPerson(otherAssignees[index].children[2].textContent!);
       }
       showMore.click();
     };

--- a/src/util/klondike.ts
+++ b/src/util/klondike.ts
@@ -1,10 +1,24 @@
-export function highlightSwimLane(personName: string): void {
-  closeAllSwimLanes();
-  const personHeader = openSwimLane(personName);
-  scrollToHeader(personHeader);
+export function highlightPerson(personName: string): void {
+  if (usesSwimLanes()) {
+    closeAllSwimLanes();
+    const personHeader = openSwimLane(personName);
+    scrollToHeader(personHeader);
+  } else {
+    // Otherwise use assignee filter instead
+    uncheckAssignees();
+    checkAssignee(personName);
+  }
 }
 
-export function closeAllSwimLanes(): void {
+export function closePeopleFilters(): void {
+  if (usesSwimLanes()) {
+    closeAllSwimLanes();
+  } else {
+    uncheckAssignees();
+  }
+}
+
+function closeAllSwimLanes(): void {
   const expanders = document.querySelectorAll<HTMLButtonElement>(
     '.ghx-swimlane:not(.ghx-closed) .ghx-expander',
   );
@@ -75,4 +89,57 @@ function doesNameMatchHeader(personName: string, headerText: string): boolean {
   }
 
   return true;
+}
+
+function usesSwimLanes(): boolean {
+  return document.querySelector('.ghx-swimlane-header') !== null;
+}
+
+function uncheckAssignees(): void {
+  const checkedAssignees = document.querySelectorAll<HTMLInputElement>(
+    'input[name="ASSIGNEE"]:checked',
+  );
+  checkedAssignees.forEach((checkedAssignees) => checkedAssignees.click());
+
+  const showMore = document.querySelector<HTMLElement>('#ASSIGNEE-show-more');
+  if (!showMore) return;
+
+  showMore.click();
+  const otherAssignees = document.querySelectorAll<HTMLSpanElement>(
+    "span[data-role='droplistItem'][aria-checked='true']",
+  );
+
+  otherAssignees.forEach((checkedAssignees) => checkedAssignees.click());
+  showMore.click();
+}
+
+function checkAssignee(personName: string): void {
+  const assignees = document.querySelectorAll<HTMLElement>(
+    "label[data-test-id='common.issue-filter-bar.assignee-filter-avatar'] span[role='img']",
+  );
+  for (let index = 0; index < assignees.length; index++) {
+    const assignee = assignees[index];
+    const assigneeName = assignee.getAttribute('aria-label')!;
+    if (doesNameMatchHeader(personName, assigneeName)) {
+      assignee.click();
+      return;
+    }
+  }
+  const showMore = document.querySelector<HTMLElement>('#ASSIGNEE-show-more');
+  if (!showMore) return;
+
+  showMore.click();
+  const otherAssignees = document.querySelectorAll<HTMLSpanElement>(
+    "span[data-role='droplistItem']",
+  );
+  for (let index = 0; index < otherAssignees.length; index++) {
+    const assignee = otherAssignees[index];
+    const assigneeName = assignee.children[2].textContent!;
+    if (doesNameMatchHeader(personName, assigneeName)) {
+      assignee.click();
+      showMore.click();
+      return;
+    }
+  }
+  showMore.click();
 }

--- a/src/util/klondike.ts
+++ b/src/util/klondike.ts
@@ -137,8 +137,7 @@ function checkAssignee(personName: string): void {
     const assigneeName = assignee.children[2].textContent!;
     if (doesNameMatchHeader(personName, assigneeName)) {
       assignee.click();
-      showMore.click();
-      return;
+      break;
     }
   }
   showMore.click();


### PR DESCRIPTION
## Context
Each user needed to previously be manually added in and would only highlight the current user when the jira board had swimlanes enabled. 

### Updates
Add "Import from active sprint" button when there is an empty standup - imports from the users in the assignee filter

<img width="329" alt="Screenshot 2023-03-17 at 8 38 52 AM" src="https://user-images.githubusercontent.com/6825695/225909061-97f3ebb7-2786-48be-9247-43321d104f02.png">

When the user is attempted to be highlighted it will now default to using the assignee filter if the board doesn't use swim lanes 