### PR TITLE
Make checking assignees the default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.DS_Store
 /node_modules
 /build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "standup",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A chrome extension to help facilitate standup meetings.",
   "scripts": {
     "build": "webpack --config webpack.config.js",

--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -7,7 +7,7 @@ import Icebreaker from '../icebreaker';
 import PersonsList from '../persons-list';
 import { loadPersons, deletePerson, savePerson } from '../../util/idb';
 import { getPersonIndex } from '../../util';
-import { closePeopleFilters, highlightPerson } from '../../util/jira';
+import { highlightPerson, uncheckAssignees } from '../../util/jira';
 import type { Person } from '../../util/types';
 import './index.scss';
 
@@ -23,7 +23,7 @@ export default function App() {
     if (nextPerson) {
       highlightPerson(nextPerson.name);
     } else {
-      closePeopleFilters();
+      uncheckAssignees();
     }
   }, [persons]);
 
@@ -121,7 +121,7 @@ export default function App() {
     });
 
     setActivePersonId(undefined);
-    closePeopleFilters();
+    uncheckAssignees();
   };
 
   const onSelectNextPerson = (personId: string) => {

--- a/src/components/persons-list/index.tsx
+++ b/src/components/persons-list/index.tsx
@@ -303,14 +303,9 @@ export default function PersonsList(props: PersonsListProps) {
 
   const getEmptyMessage = () => {
     const onImportClick = () => {
-      // TODO: Remove old selectors once enhanced Jira is the default
-      const originalAvatarSelector =
-        "label[data-testid='common.issue-filter-bar.assignee-filter-avatar'] img";
-      const enhancedAvatarSelector =
+      const avatarSelector =
         "label[data-test-id='filters.ui.filters.assignee.stateless.avatar.assignee-filter-avatar'] img";
-      const assignees = document.querySelectorAll(
-        `${originalAvatarSelector}, ${enhancedAvatarSelector}`,
-      );
+      const assignees = document.querySelectorAll(avatarSelector);
       assignees.forEach((assignee) => {
         const assigneeName = assignee.getAttribute('alt');
         if (assigneeName) props.onAddPerson(assigneeName);
@@ -323,12 +318,8 @@ export default function PersonsList(props: PersonsListProps) {
 
       showMore.click();
 
-      const originalOtherSelector = ".atlaskit-portal-container button[role='checkbox'] img";
-      const enhancedOtherSelector =
-        ".atlaskit-portal-container button[role='menuitemcheckbox'] img";
-      const otherAssignees = document.querySelectorAll(
-        `${originalOtherSelector}, ${enhancedOtherSelector}`,
-      );
+      const otherSelector = ".atlaskit-portal-container button[role='menuitemcheckbox'] img";
+      const otherAssignees = document.querySelectorAll(otherSelector);
 
       for (let index = 0; index < otherAssignees.length; index++) {
         const assigneeName = otherAssignees[index].getAttribute('alt');

--- a/src/util/jira.ts
+++ b/src/util/jira.ts
@@ -1,126 +1,32 @@
-// TODO: Remove old selectors once enhanced Jira is the default
-const BOARD_SELECTOR_ORIGINAL = '#ghx-pool-column';
-const HEADER_SELECTOR_ORIGINAL = '.ghx-swimlane-header';
-const HEADER_TEXT_SELECTOR_ORIGINAL = '.ghx-heading span';
-const EXPANDER_SELECTOR_ORIGINAL = '.ghx-expander';
-const OTHER_ASSIGNEES_SELECTOR_ORIGINAL = ".atlaskit-portal-container button[role='checkbox']";
-const AVATAR_SELECTOR_ORIGINAL =
-  "label[data-testid='common.issue-filter-bar.assignee-filter-avatar'] img";
-
 const CHECKED_ASSIGNEE_SELECTOR = 'input[name="ASSIGNEE"]:checked, input[name="assignee"]:checked';
 const ASSIGNEE_SHOW_MORE_SELECTOR = '#ASSIGNEE-show-more, #assignee-show-more';
 
-const BOARD_SELECTOR_ENHANCED = '[data-test-id="platform-board-kit.ui.board.scroll.board-scroll"]';
-const HEADER_SELECTOR_ENHANCED =
+const HEADER_SELECTOR =
   '[data-test-id="platform-board-kit.ui.swimlane.swimlane-wrapper"] > div:nth-child(3)';
-const EXPANDER_SELECTOR_ENHANCED =
-  '[data-test-id="platform-board-kit.ui.swimlane.swimlane-content"]';
-const OTHER_ASSIGNEES_SELECTOR_ENHANCED =
-  ".atlaskit-portal-container button[role='menuitemcheckbox']";
-const AVATAR_SELECTOR_ENHANCED =
+const EXPANDER_SELECTOR = '[data-test-id="platform-board-kit.ui.swimlane.swimlane-content"]';
+const OTHER_ASSIGNEES_SELECTOR = ".atlaskit-portal-container button[role='menuitemcheckbox']";
+const AVATAR_SELECTOR =
   "label[data-test-id='filters.ui.filters.assignee.stateless.avatar.assignee-filter-avatar'] img";
 
 export function highlightPerson(personName: string): void {
-  if (usesSwimLanes()) {
-    closeAllSwimLanes();
-    const personHeader = openSwimLane(personName);
-    scrollToHeader(personHeader);
-  } else {
-    // Otherwise use assignee filter instead
-    uncheckAssignees();
-    checkAssignee(personName);
-  }
+  uncheckAssignees();
+  checkAssignee(personName);
+  openAllSwimLanes();
 }
 
-export function closePeopleFilters(): void {
-  if (usesSwimLanes()) {
-    closeAllSwimLanes();
-  } else {
-    uncheckAssignees();
-  }
-}
+function openAllSwimLanes(): void {
+  // Wait for swimlanes to appear on the board before opening them
+  // TODO: Figure out a way to do this cleaner
+  setTimeout(() => {
+    const selector = `${HEADER_SELECTOR} ${EXPANDER_SELECTOR}[aria-expanded="false"]`;
+    const expanders = document.querySelectorAll<HTMLButtonElement>(selector);
+    console.log(expanders);
 
-function closeAllSwimLanes(): void {
-  const originalSelector = `.ghx-swimlane:not(.ghx-closed) ${EXPANDER_SELECTOR_ORIGINAL}`;
-  const enhancedSelector = `${HEADER_SELECTOR_ENHANCED} ${EXPANDER_SELECTOR_ENHANCED}[aria-expanded="true"]`;
-  const expanders = document.querySelectorAll<HTMLButtonElement>(
-    `${originalSelector}, ${enhancedSelector}`,
-  );
-
-  for (let expanderIdx = 0; expanderIdx < expanders.length; expanderIdx += 1) {
-    const expander = expanders[expanderIdx];
-    expander.click();
-  }
-}
-
-function openSwimLane(personName: string): HTMLElement | undefined {
-  const headers = document.querySelectorAll<HTMLElement>(
-    `${HEADER_SELECTOR_ORIGINAL}, ${HEADER_SELECTOR_ENHANCED}`,
-  );
-  let defaultHeader: HTMLElement | null | undefined;
-
-  for (let headerIdx = 0; headerIdx < headers.length; headerIdx += 1) {
-    const header = headers[headerIdx];
-    const originalTextElement = header.querySelector(HEADER_TEXT_SELECTOR_ORIGINAL);
-    const enhancedTextElement1 = header.querySelector(
-      `${EXPANDER_SELECTOR_ENHANCED} > div > div:nth-child(2)`,
-    );
-    const enhancedTextElement2 = header.querySelector(
-      `${EXPANDER_SELECTOR_ENHANCED} > div > div:nth-child(3)`,
-    );
-
-    const headerText =
-      originalTextElement?.textContent?.trim() ||
-      enhancedTextElement1?.textContent?.trim() ||
-      enhancedTextElement2?.textContent?.trim() ||
-      '';
-
-    if (doesNameMatchHeader(personName, headerText)) {
-      const expander = getExpanderFromHeader(header);
-      expander?.click();
-      return header;
-    } else if (headerText === 'Unassigned') {
-      defaultHeader = header;
+    for (let expanderIdx = expanders.length - 1; expanderIdx >= 0; expanderIdx -= 1) {
+      const expander = expanders[expanderIdx];
+      expander.click();
     }
-  }
-
-  // Open default swim lane if there is no swimlane for the person
-  if (defaultHeader) {
-    const expander = getExpanderFromHeader(defaultHeader);
-    expander?.click();
-    return defaultHeader;
-  }
-}
-
-function getExpanderFromHeader(personHeader: HTMLElement): HTMLButtonElement | null {
-  return personHeader.querySelector<HTMLButtonElement>(
-    `${EXPANDER_SELECTOR_ORIGINAL}, ${EXPANDER_SELECTOR_ENHANCED}`,
-  );
-}
-
-function scrollToHeader(personHeader?: HTMLElement): void {
-  if (!personHeader) return;
-
-  const originalBoard = document.querySelector(BOARD_SELECTOR_ORIGINAL);
-  const enhancedBoard = document.querySelector(BOARD_SELECTOR_ENHANCED);
-
-  const headerHeight = personHeader.offsetHeight;
-  const columnsYOffset = (personHeader.nextElementSibling as HTMLElement)?.offsetTop || 0;
-
-  if (originalBoard) {
-    originalBoard.scrollTo({
-      behavior: 'smooth',
-      left: 0,
-      top: columnsYOffset - headerHeight,
-    });
-  } else if (enhancedBoard) {
-    const doubleHeaderHeight = 2 * headerHeight;
-    enhancedBoard.scrollTo({
-      behavior: 'smooth',
-      left: 0,
-      top: columnsYOffset - doubleHeaderHeight,
-    });
-  }
+  }, 100);
 }
 
 function doesNameMatchHeader(personName: string, headerText: string): boolean {
@@ -148,14 +54,7 @@ function doesNameMatchHeader(personName: string, headerText: string): boolean {
   return true;
 }
 
-function usesSwimLanes(): boolean {
-  return (
-    document.querySelector(HEADER_SELECTOR_ORIGINAL) !== null ||
-    document.querySelectorAll(HEADER_SELECTOR_ENHANCED).length > 0
-  );
-}
-
-function uncheckAssignees(): void {
+export function uncheckAssignees(): void {
   const checkedAssignees = document.querySelectorAll<HTMLInputElement>(CHECKED_ASSIGNEE_SELECTOR);
   checkedAssignees.forEach((checkedAssignees) => checkedAssignees.click());
 
@@ -165,7 +64,7 @@ function uncheckAssignees(): void {
   showMore.click();
 
   const checkedOtherAssignees = document.querySelectorAll<HTMLSpanElement>(
-    `${OTHER_ASSIGNEES_SELECTOR_ORIGINAL} [aria-checked='true'], ${OTHER_ASSIGNEES_SELECTOR_ENHANCED}[aria-checked='true']`,
+    `${OTHER_ASSIGNEES_SELECTOR}[aria-checked='true']`,
   );
 
   checkedOtherAssignees.forEach((checkedAssignees) => checkedAssignees.click());
@@ -173,9 +72,7 @@ function uncheckAssignees(): void {
 }
 
 function checkAssignee(personName: string): void {
-  const assignees = document.querySelectorAll<HTMLElement>(
-    `${AVATAR_SELECTOR_ORIGINAL}, ${AVATAR_SELECTOR_ENHANCED}`,
-  );
+  const assignees = document.querySelectorAll<HTMLElement>(AVATAR_SELECTOR);
   for (let index = 0; index < assignees.length; index++) {
     const assignee = assignees[index];
     const assigneeName = assignee.getAttribute('alt');
@@ -188,11 +85,8 @@ function checkAssignee(personName: string): void {
   if (!showMore) return;
 
   showMore.click();
-  const originalOtherImageSelector = `${OTHER_ASSIGNEES_SELECTOR_ORIGINAL} img`;
-  const enhancedOtherImageSelector = `${OTHER_ASSIGNEES_SELECTOR_ENHANCED} img`;
-  const otherAssigneeImages = document.querySelectorAll<HTMLElement>(
-    `${originalOtherImageSelector}, ${enhancedOtherImageSelector}`,
-  );
+  const imageSelector = `${OTHER_ASSIGNEES_SELECTOR} img`;
+  const otherAssigneeImages = document.querySelectorAll<HTMLElement>(imageSelector);
 
   for (let index = 0; index < otherAssigneeImages.length; index++) {
     const assignee = otherAssigneeImages[index];

--- a/src/util/sidebar.tsx
+++ b/src/util/sidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import App from '../components/app';
 
 const BODY_CLASS = 'standup-body';
@@ -11,7 +11,9 @@ const SIDEBAR_ID = 'standup-sidebar';
  * Renders the standup application within the sidebar.
  */
 function renderApplication() {
-  ReactDOM.render(<App />, document.getElementById(ROOT_ID));
+  const container = document.getElementById(ROOT_ID);
+  const root = createRoot(container!);
+  root.render(<App />);
 }
 
 /**


### PR DESCRIPTION
This PR removes the swimlane method of displaying users in favour of using the assignees menu to display users on kanban boards universally. Jira is now lazy loading swimlanes which makes it difficult to open/close swimlanes as the extension was doing before.